### PR TITLE
docs: add Homebrew install and uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ t=0s─────────────────────────�
 
 ## Installation
 
+### Homebrew (macOS & Linux)
+
+```bash
+brew tap arthurrio/dirtop
+brew install dirtop
+```
+
 ### One-line install (Linux & macOS)
 
 ```bash
@@ -49,6 +56,33 @@ git clone https://github.com/arthurrio/dirtop.git
 cd dirtop
 go build -o dirtop .
 sudo mv dirtop /usr/local/bin/
+```
+
+## Uninstall
+
+### Homebrew
+
+```bash
+brew uninstall dirtop
+brew untap arthurrio/dirtop
+```
+
+### Go install
+
+```bash
+rm $(which dirtop)
+```
+
+Or, if installed to the default Go bin directory:
+
+```bash
+rm ~/go/bin/dirtop
+```
+
+### Manual / install.sh
+
+```bash
+sudo rm /usr/local/bin/dirtop
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

- Add Homebrew as the primary installation method (`brew tap arthurrio/dirtop && brew install dirtop`)
- Add uninstall instructions for all three install methods: Homebrew, Go install, and manual/install.sh