### PR TITLE
Add dev-mode scan ignores for generated files and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ dirtop --intervals 1,10,60
 dirtop -i 10 --intervals 1,10,60 ~/code/myproject
 ```
 
-With `--dev`, `dirtop` skips common development-only paths such as `node_modules`, `vendor`, `target`, `.gradle`, `.terraform`, `__pycache__`, `.idea`, `.vscode`, `dist`, `build`, and generated files like `*.iml`, `*.class`, `*.so`, and `*.min.js.map`. Project config files such as `package.json`, `pom.xml`, `Cargo.toml`, and `tsconfig.json` are still counted.
-The full directory list ignored by `--dev` is defined in [scanner.go](/home/thurrio/workspace/dirtop/scanner.go#L14).
+With `--dev`, `dirtop` skips common development-only paths such as `node_modules`, `vendor`, `target`, `__pycache__`, `dist`, `build`, and generated files like `*.iml`, `*.class`, `*.so`, and `*.min.js.map`. Hidden directories (e.g. `.git`, `.idea`, `.vscode`) are always ignored regardless of `--dev`. Project config files such as `package.json`, `pom.xml`, `Cargo.toml`, and `tsconfig.json` are still counted.
+The full directory list ignored by `--dev` is defined in [scanner.go](scanner.go).
 
 ## Keyboard shortcuts
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ If no directory is given, the current working directory is used.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--dev` | `false` | Ignore common dependency, build, cache, IDE, VCS directories and generated files |
+| `--ignore-dirs <list>` | `""` | Additional directory names to ignore, comma-separated |
 | `-i <seconds>` | `1` | Starting refresh interval |
 | `--intervals <list>` | `1,5,10,30,60` | Available intervals to cycle through (comma-separated, in seconds) |
 
@@ -116,6 +117,9 @@ dirtop -i 5
 # Ignore common dependency and IDE directories
 dirtop --dev
 
+# Ignore custom directories by name
+dirtop --ignore-dirs generated,coverage,tmp
+
 # Use a custom interval list
 dirtop --intervals 1,10,60
 
@@ -124,6 +128,7 @@ dirtop -i 10 --intervals 1,10,60 ~/code/myproject
 ```
 
 With `--dev`, `dirtop` skips common development-only paths such as `node_modules`, `vendor`, `target`, `.gradle`, `.terraform`, `__pycache__`, `.idea`, `.vscode`, `dist`, `build`, and generated files like `*.iml`, `*.class`, `*.so`, and `*.min.js.map`. Project config files such as `package.json`, `pom.xml`, `Cargo.toml`, and `tsconfig.json` are still counted.
+The full directory list ignored by `--dev` is defined in [scanner.go](/home/thurrio/workspace/dirtop/scanner.go#L14).
 
 ## Keyboard shortcuts
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ If no directory is given, the current working directory is used.
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--dev` | `false` | Ignore common dependency, build, cache, IDE, VCS directories and generated files |
 | `-i <seconds>` | `1` | Starting refresh interval |
 | `--intervals <list>` | `1,5,10,30,60` | Available intervals to cycle through (comma-separated, in seconds) |
 
@@ -112,12 +113,17 @@ dirtop ~/code/myproject
 # Start with a 5-second interval
 dirtop -i 5
 
+# Ignore common dependency and IDE directories
+dirtop --dev
+
 # Use a custom interval list
 dirtop --intervals 1,10,60
 
 # Combine flags and path
 dirtop -i 10 --intervals 1,10,60 ~/code/myproject
 ```
+
+With `--dev`, `dirtop` skips common development-only paths such as `node_modules`, `vendor`, `target`, `.gradle`, `.terraform`, `__pycache__`, `.idea`, `.vscode`, `dist`, `build`, and generated files like `*.iml`, `*.class`, `*.so`, and `*.min.js.map`. Project config files such as `package.json`, `pom.xml`, `Cargo.toml`, and `tsconfig.json` are still counted.
 
 ## Keyboard shortcuts
 

--- a/chart.go
+++ b/chart.go
@@ -9,58 +9,58 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Mapeamento dos pontos braille para bits no bloco U+2800.
-// Coluna esquerda: pontos 1,2,3,7 → bits 0,1,2,6
-// Coluna direita:  pontos 4,5,6,8 → bits 3,4,5,7
-// Cada célula cobre 2 colunas × 4 linhas.
-var brailleLeft = [4]uint8{0, 1, 2, 6}  // bits para linhas 0-3 da coluna esquerda
-var brailleRight = [4]uint8{3, 4, 5, 7} // bits para linhas 0-3 da coluna direita
+// Mapping of braille dots to bits in the U+2800 block.
+// Left column: dots 1,2,3,7 -> bits 0,1,2,6
+// Right column: dots 4,5,6,8 -> bits 3,4,5,7
+// Each cell covers 2 columns x 4 rows.
+var brailleLeft = [4]uint8{0, 1, 2, 6}  // Bits for rows 0-3 in the left column.
+var brailleRight = [4]uint8{3, 4, 5, 7} // Bits for rows 0-3 in the right column.
 
-// Render renderiza um gráfico de linha com área preenchida usando caracteres braille.
+// Render draws a line chart with a filled area using braille characters.
 //
-// O parâmetro height inclui a linha do eixo X.
-// A área de desenho usa height-1 linhas; a última linha é sempre o eixo X.
+// The height parameter includes the X-axis row.
+// The drawing area uses height-1 rows; the last row is always the X-axis.
 //
-// Se values for vazio ou todos zeros, retorna um bloco de espaços width×height.
+// If values is empty or all zeros, it returns a width x height block of spaces.
 func Render(values []int, width, height int) string {
 	if height < 2 {
 		height = 2
 	}
 
-	chartRows := height - 1 // linhas disponíveis para o gráfico braille
+	chartRows := height - 1 // Available rows for the braille chart.
 
-	// Caso vazio ou todos zeros
+	// Empty or all-zero input.
 	maxVal := maxInt(values)
 	if maxVal == 0 {
 		return blankBlock(width, height)
 	}
 
-	// Truncar se necessário: cada célula braille usa 2 valores
+	// Truncate if needed: each braille cell uses 2 values.
 	maxValues := width * 2
 	if len(values) > maxValues {
 		values = values[len(values)-maxValues:]
 	}
-	totalDots := chartRows * 4 // pontos verticais disponíveis
+	totalDots := chartRows * 4 // Available vertical dots.
 
-	// Normalizar valores para [0, totalDots]
+	// Normalize values into [0, totalDots].
 	normalized := make([]int, len(values))
 	for i, v := range values {
 		normalized[i] = v * totalDots / maxVal
 	}
 
-	// Construir grade de células braille: [linha][coluna]
+	// Build the braille cell grid: [row][column].
 	cols := (len(normalized) + 1) / 2
 	if cols > width {
 		cols = width
 	}
 
-	// grid[row][col] = bitmask do caractere braille
+	// grid[row][col] = bitmask for the braille character.
 	grid := make([][]uint8, chartRows)
 	for i := range grid {
 		grid[i] = make([]uint8, cols)
 	}
 
-	// Preencher o grid
+	// Fill the grid.
 	for colIdx := 0; colIdx < cols; colIdx++ {
 		leftIdx := colIdx * 2
 		rightIdx := leftIdx + 1
@@ -74,7 +74,7 @@ func Render(values []int, width, height int) string {
 			rightVal = normalized[rightIdx]
 		}
 
-		// Acender pontos da base até o valor
+		// Light dots from the baseline up to the value.
 		for dotRow := 0; dotRow < leftVal; dotRow++ {
 			row := chartRows - 1 - dotRow/4
 			bit := 3 - (dotRow % 4)
@@ -91,10 +91,10 @@ func Render(values []int, width, height int) string {
 		}
 	}
 
-	// Determinar a linha "topo" de cada coluna (linha vs área)
+	// Determine the top row of each column for the line overlay.
 	topRow := make([]int, cols)
 	for colIdx := 0; colIdx < cols; colIdx++ {
-		topRow[colIdx] = chartRows // default: sem valor
+		topRow[colIdx] = chartRows // Default: no value.
 		for row := 0; row < chartRows; row++ {
 			if grid[row][colIdx] != 0 {
 				topRow[colIdx] = row
@@ -133,14 +133,14 @@ func Render(values []int, width, height int) string {
 		sb.WriteString(strings.Join(line, ""))
 	}
 
-	// Eixo X
+	// X-axis.
 	sb.WriteString("\n")
 	sb.WriteString(renderXAxis(width))
 
 	return sb.String()
 }
 
-// renderXAxis retorna a linha do eixo X com "t=0s" à esquerda e "agora" à direita.
+// renderXAxis returns the X-axis row with "t=0s" on the left and "now" on the right.
 func renderXAxis(width int) string {
 	left := "t=0s"
 	right := "now"
@@ -157,7 +157,7 @@ func renderXAxis(width int) string {
 	)
 }
 
-// blankBlock retorna um bloco de espaços com exatamente width×height caracteres.
+// blankBlock returns a block of spaces with exactly width x height characters.
 func blankBlock(width, height int) string {
 	row := strings.Repeat(" ", width)
 	rows := make([]string, height)
@@ -167,7 +167,7 @@ func blankBlock(width, height int) string {
 	return strings.Join(rows, "\n")
 }
 
-// maxInt retorna o maior valor de um slice de inteiros.
+// maxInt returns the largest value in an integer slice.
 func maxInt(vals []int) int {
 	if len(vals) == 0 {
 		return 0
@@ -181,21 +181,21 @@ func maxInt(vals []int) int {
 	return m
 }
 
-// ─── Modos de gráfico ────────────────────────────────────────────────────────
+// ─── Chart Modes ─────────────────────────────────────────────────────────────
 
-// ChartMode define o tipo de visualização do histórico.
+// ChartMode defines the history visualization type.
 type ChartMode int
 
 const (
-	ChartHorizBar  ChartMode = iota // histograma horizontal de blocos (padrão)
-	ChartBraille                    // área preenchida
-	ChartSparkline                  // apenas a linha, sem preenchimento
-	ChartMultiLine                  // três métricas sobrepostas
-	ChartDelta                      // variação (Δ) em relação ao ponto anterior
+	ChartHorizBar  ChartMode = iota // Horizontal block histogram (default).
+	ChartBraille                    // Filled area.
+	ChartSparkline                  // Line only, no fill.
+	ChartMultiLine                  // Three overlaid metrics.
+	ChartDelta                      // Delta versus the previous point.
 	chartModeCount
 )
 
-// Name retorna o nome legível do modo de gráfico.
+// Name returns the user-facing chart mode name.
 func (m ChartMode) Name() string {
 	names := [...]string{"bars", "area", "line", "multi", "delta"}
 	if int(m) < len(names) {
@@ -206,7 +206,7 @@ func (m ChartMode) Name() string {
 
 // ─── Sparkline ───────────────────────────────────────────────────────────────
 
-// RenderSparkline renderiza apenas a linha do gráfico, sem preenchimento.
+// RenderSparkline renders only the chart line, without fill.
 func RenderSparkline(values []int, width, height int) string {
 	if height < 2 {
 		height = 2
@@ -238,7 +238,7 @@ func RenderSparkline(values []int, width, height int) string {
 		grid[i] = make([]uint8, cols)
 	}
 
-	// Acende apenas o ponto mais alto de cada sub-coluna (sem preenchimento)
+	// Light only the highest dot of each sub-column, without fill.
 	setTopBit := func(colIdx, val int, bits [4]uint8) {
 		if val <= 0 {
 			return
@@ -284,11 +284,11 @@ func RenderSparkline(values []int, width, height int) string {
 	return sb.String()
 }
 
-// ─── Multi-linha ─────────────────────────────────────────────────────────────
+// ─── Multi-Line ──────────────────────────────────────────────────────────────
 
-// RenderMultiLine renderiza três métricas sobrepostas no mesmo gráfico braille.
-// Cada série é normalizada de forma independente para melhor visibilidade.
-// Prioridade de cor em conflito de célula: linhas > arquivos > pastas.
+// RenderMultiLine renders three overlaid metrics in the same braille chart.
+// Each series is normalized independently for better visibility.
+// Color priority on cell conflicts: lines > files > dirs.
 func RenderMultiLine(files, dirs, lines []int, width, height int) string {
 	if height < 2 {
 		height = 2
@@ -296,7 +296,7 @@ func RenderMultiLine(files, dirs, lines []int, width, height int) string {
 	chartRows := height - 1
 	maxValues := width * 2
 
-	// Ordem de desenho: dirs (menor prioridade) → files → lines (maior prioridade)
+	// Draw order: dirs (lowest priority) -> files -> lines (highest priority).
 	type series struct {
 		vals  []int
 		color string
@@ -381,7 +381,7 @@ func RenderMultiLine(files, dirs, lines []int, width, height int) string {
 		sb.WriteString(strings.Join(line, ""))
 	}
 	sb.WriteString("\n")
-	// Legenda substitui o eixo X
+	// The legend replaces the X-axis.
 	legendL := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPurple)).Render("─ lines")
 	legendF := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorBlue)).Render("─ files")
 	legendD := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorGreen)).Render("─ dirs")
@@ -391,8 +391,8 @@ func RenderMultiLine(files, dirs, lines []int, width, height int) string {
 
 // ─── Delta ───────────────────────────────────────────────────────────────────
 
-// RenderDelta renderiza a variação (Δ) entre amostras consecutivas.
-// Crescimento aparece acima da linha central (verde), queda abaixo (laranja).
+// RenderDelta renders the delta between consecutive samples.
+// Growth appears above the center line in green, decline below it in orange.
 func RenderDelta(values []int, width, height int) string {
 	if height < 2 {
 		height = 2
@@ -515,9 +515,9 @@ func RenderDelta(values []int, width, height int) string {
 	return sb.String()
 }
 
-// ─── Histograma horizontal ───────────────────────────────────────────────────
+// ─── Horizontal Histogram ────────────────────────────────────────────────────
 
-// formatAgo formata uma duração de offset como "-5s", "-2m", "-1h".
+// formatAgo formats an offset duration as "-5s", "-2m", or "-1h".
 func formatAgo(d time.Duration) string {
 	if d <= 0 {
 		return "now"
@@ -532,9 +532,9 @@ func formatAgo(d time.Duration) string {
 	return fmt.Sprintf("-%dh", s/3600)
 }
 
-// RenderHorizBar renderiza um histograma horizontal com barras de blocos.
-// Cada linha representa uma amostra; a mais recente fica no topo.
-// interval é o tempo real entre cada amostra, usado para calcular os labels de tempo.
+// RenderHorizBar renders a horizontal histogram using block bars.
+// Each row represents one sample, with the most recent at the top.
+// interval is the real time between samples and is used to compute time labels.
 func RenderHorizBar(values []int, width, height int, interval time.Duration) string {
 	if interval <= 0 {
 		interval = time.Second
@@ -547,22 +547,22 @@ func RenderHorizBar(values []int, width, height int, interval time.Duration) str
 		return blankBlock(width, height)
 	}
 
-	// Mostrar os últimos `height` samples (mais recente no topo)
+	// Show the last `height` samples, most recent first.
 	samples := values
 	if len(samples) > height {
 		samples = samples[len(samples)-height:]
 	}
 	n := len(samples)
 
-	// Calcular labelWidth dinamicamente pelo pior caso visível
+	// Compute labelWidth dynamically from the visible worst case.
 	maxOffset := time.Duration(n-1) * interval
 	labelWidth := len(formatAgo(maxOffset))
 	if labelWidth < len("now") {
 		labelWidth = len("now")
 	}
 
-	const valueWidth = 10 // número formatado alinhado à direita
-	// layout por linha: label + " " + bar + " " + value
+	const valueWidth = 10 // Right-aligned formatted number.
+	// Per-row layout: label + " " + bar + " " + value.
 	barArea := width - labelWidth - 2 - valueWidth
 	if barArea < 1 {
 		barArea = 1
@@ -577,7 +577,7 @@ func RenderHorizBar(values []int, width, height int, interval time.Duration) str
 		if i > 0 {
 			sb.WriteString("\n")
 		}
-		sampleIdx := n - 1 - i // índice 0 = mais recente no topo
+		sampleIdx := n - 1 - i // Index 0 is the most recent sample at the top.
 		if sampleIdx < 0 {
 			sb.WriteString(strings.Repeat(" ", width))
 			continue

--- a/chart_test.go
+++ b/chart_test.go
@@ -10,12 +10,12 @@ func TestRender_EmptyInput(t *testing.T) {
 	result := Render([]int{}, 20, 5)
 	lines := strings.Split(result, "\n")
 
-	// Deve retornar exatamente `height` linhas
+	// It should return exactly `height` rows.
 	if len(lines) != 5 {
 		t.Errorf("esperado 5 linhas, obtido %d", len(lines))
 	}
 
-	// Cada linha deve ter largura width (espaços)
+	// Each row should have width characters made of spaces.
 	for i, line := range lines {
 		stripped := stripANSI(line)
 		if len([]rune(stripped)) != 20 {
@@ -56,8 +56,8 @@ func TestRender_OutputHeightMatchesParam(t *testing.T) {
 }
 
 func TestRender_TruncatesLongHistory(t *testing.T) {
-	// width=10 → suporta 20 valores (2 por célula braille)
-	// passar 30 valores não deve causar pânico
+	// width=10 -> supports 20 values (2 per braille cell).
+	// Passing 30 values should not panic.
 	values := make([]int, 30)
 	for i := range values {
 		values[i] = i * 10
@@ -69,7 +69,7 @@ func TestRender_TruncatesLongHistory(t *testing.T) {
 }
 
 func TestRender_ContainsBrailleChars(t *testing.T) {
-	// A single non-zero value should produce at least one braille character
+	// A single non-zero value should produce at least one braille character.
 	result := Render([]int{10}, 10, 5)
 	hasBraille := false
 	for _, r := range result {
@@ -84,14 +84,14 @@ func TestRender_ContainsBrailleChars(t *testing.T) {
 }
 
 func TestRender_MinHeight(t *testing.T) {
-	// height=1 should be clamped to 2
+	// height=1 should be clamped to 2.
 	result := Render([]int{5, 10}, 20, 1)
 	lines := strings.Split(result, "\n")
 	if len(lines) != 2 {
 		t.Errorf("height=1 deve produzir 2 linhas (mínimo), obtido %d", len(lines))
 	}
 
-	// height=2 should produce exactly 2 lines
+	// height=2 should produce exactly 2 lines.
 	result2 := Render([]int{5, 10}, 20, 2)
 	lines2 := strings.Split(result2, "\n")
 	if len(lines2) != 2 {
@@ -99,7 +99,7 @@ func TestRender_MinHeight(t *testing.T) {
 	}
 }
 
-// stripANSI remove sequências de escape ANSI de uma string.
+// stripANSI removes ANSI escape sequences from a string.
 func stripANSI(s string) string {
 	var result strings.Builder
 	inEscape := false

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var version = "dev"
 func main() {
 	flagVersion := flag.Bool("version", false, "print version and exit")
 	flagDev := flag.Bool("dev", false, "ignore common dependency, build, IDE, and cache directories")
+	flagIgnoreDirs := flag.String("ignore-dirs", "", "additional directory names to ignore, comma-separated (e.g. --ignore-dirs dist,coverage,tmp)")
 	flagInterval := flag.Int("i", 0, "starting refresh interval in seconds (e.g. -i 5)")
 	flagIntervals := flag.String("intervals", "", "available intervals in seconds, comma-separated (e.g. --intervals 1,5,10,30,60)")
 	flag.Parse()
@@ -45,7 +46,7 @@ func main() {
 
 	m := Model{
 		cwd:         cwd,
-		scanOpts:    ScanOptions{DevMode: *flagDev},
+		scanOpts:    ScanOptions{DevMode: *flagDev, IgnoreDirs: parseList(*flagIgnoreDirs)},
 		width:       80,
 		height:      24,
 		intervals:   intervals,
@@ -106,6 +107,28 @@ func parseIntervals(rawList string, startSecs int) []time.Duration {
 	}
 
 	return durations
+}
+
+// parseList parses a comma-separated list, trims whitespace, and removes duplicates.
+func parseList(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var items []string
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if _, ok := seen[part]; ok {
+			continue
+		}
+		seen[part] = struct{}{}
+		items = append(items, part)
+	}
+	return items
 }
 
 // findIntervalIdx returns the index of startSecs in the list, or 0 if not provided.

--- a/main.go
+++ b/main.go
@@ -28,13 +28,13 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Verificar acesso ao diretório atual antes de iniciar a TUI
+	// Check access to the current directory before starting the TUI.
 	if _, err := os.ReadDir("."); err != nil {
 		fmt.Fprintf(os.Stderr, "error: cannot access current directory: %v\n", err)
 		os.Exit(1)
 	}
 
-	// Resolver path absoluto para exibição
+	// Resolve the absolute path for display.
 	cwd, err := os.Getwd()
 	if err != nil {
 		cwd = "."
@@ -59,9 +59,9 @@ func main() {
 	}
 }
 
-// parseIntervals constrói a lista de intervalos a partir das flags.
-// Se --intervals for fornecido, usa essa lista; caso contrário usa DefaultIntervals.
-// Se -i for fornecido e não estiver na lista, insere-o na posição correta.
+// parseIntervals builds the interval list from the CLI flags.
+// If --intervals is provided, it uses that list; otherwise it uses DefaultIntervals.
+// If -i is provided and missing from the list, it inserts it in sorted order.
 func parseIntervals(rawList string, startSecs int) []time.Duration {
 	var durations []time.Duration
 
@@ -85,11 +85,11 @@ func parseIntervals(rawList string, startSecs int) []time.Duration {
 		copy(durations, DefaultIntervals)
 	}
 
-	// Garantir ordenação e unicidade
+	// Ensure sorting and uniqueness.
 	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
 	durations = dedupDurations(durations)
 
-	// Inserir -i na lista caso não esteja presente
+	// Insert -i into the list if it is not already present.
 	if startSecs > 0 {
 		target := time.Duration(startSecs) * time.Second
 		found := false
@@ -108,7 +108,7 @@ func parseIntervals(rawList string, startSecs int) []time.Duration {
 	return durations
 }
 
-// findIntervalIdx retorna o índice de startSecs na lista, ou 0 se não fornecido.
+// findIntervalIdx returns the index of startSecs in the list, or 0 if not provided.
 func findIntervalIdx(intervals []time.Duration, startSecs int) int {
 	if startSecs <= 0 {
 		return 0
@@ -122,7 +122,7 @@ func findIntervalIdx(intervals []time.Duration, startSecs int) int {
 	return 0
 }
 
-// dedupDurations remove durações duplicadas de uma slice já ordenada.
+// dedupDurations removes duplicate durations from an already sorted slice.
 func dedupDurations(ds []time.Duration) []time.Duration {
 	if len(ds) == 0 {
 		return ds

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ var version = "dev"
 
 func main() {
 	flagVersion := flag.Bool("version", false, "print version and exit")
+	flagDev := flag.Bool("dev", false, "ignore common dependency, build, IDE, and cache directories")
 	flagInterval := flag.Int("i", 0, "starting refresh interval in seconds (e.g. -i 5)")
 	flagIntervals := flag.String("intervals", "", "available intervals in seconds, comma-separated (e.g. --intervals 1,5,10,30,60)")
 	flag.Parse()
@@ -44,6 +45,7 @@ func main() {
 
 	m := Model{
 		cwd:         cwd,
+		scanOpts:    ScanOptions{DevMode: *flagDev},
 		width:       80,
 		height:      24,
 		intervals:   intervals,

--- a/model.go
+++ b/model.go
@@ -210,6 +210,9 @@ func (m Model) View() string {
 
 	// Calculate extension rows, limited by the available space.
 	extCount := len(m.current.ByExt)
+	if extCount > 5 {
+		extCount = 5
+	}
 	extRows := (extCount + 1) / 2 // 2 columns per row
 	if extRows < 1 {
 		extRows = 1
@@ -288,6 +291,11 @@ func renderExtensions(byExt map[string]int, width int) string {
 	})
 	if noExt != nil {
 		entries = append(entries, *noExt)
+	}
+
+	const maxExtensions = 5
+	if len(entries) > maxExtensions {
+		entries = entries[:maxExtensions]
 	}
 
 	leftColWidth := (width - 1) / 2

--- a/model.go
+++ b/model.go
@@ -44,6 +44,7 @@ type Model struct {
 	history     []Stats
 	current     Stats
 	cwd         string
+	scanOpts    ScanOptions
 	width       int
 	height      int
 	chartMode   ChartMode
@@ -87,13 +88,13 @@ func formatInterval(d time.Duration) string {
 
 // Init dispara a primeira varredura imediatamente, sem esperar 1 segundo.
 func (m Model) Init() tea.Cmd {
-	return scanCmd(m.cwd)
+	return scanCmd(m.cwd, m.scanOpts)
 }
 
 // scanCmd retorna um tea.Cmd que executa a varredura no path especificado.
-func scanCmd(path string) tea.Cmd {
+func scanCmd(path string, opts ScanOptions) tea.Cmd {
 	return func() tea.Msg {
-		return ScanMsg(Scan(path))
+		return ScanMsg(Scan(path, opts))
 	}
 }
 
@@ -108,7 +109,7 @@ func tickCmd(d time.Duration) tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tickMsg:
-		return m, scanCmd(m.cwd)
+		return m, scanCmd(m.cwd, m.scanOpts)
 
 	case ScanMsg:
 		stats := Stats(msg)

--- a/model.go
+++ b/model.go
@@ -12,12 +12,12 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// tickMsg sinaliza que é hora de iniciar uma nova varredura.
+// tickMsg signals that it is time to start a new scan.
 type tickMsg time.Time
 
 const historyMaxLen = 3600
 
-// DefaultIntervals é a lista padrão de intervalos de atualização.
+// DefaultIntervals is the default list of refresh intervals.
 var DefaultIntervals = []time.Duration{
 	1 * time.Second,
 	5 * time.Second,
@@ -26,20 +26,20 @@ var DefaultIntervals = []time.Duration{
 	60 * time.Second,
 }
 
-// metricDef descreve uma métrica exibível no gráfico.
+// metricDef describes a chartable metric.
 type metricDef struct {
 	name  string
 	color string
 }
 
-// chartMetrics lista as métricas disponíveis para o gráfico (single-metric).
+// chartMetrics lists the metrics available for the single-metric chart.
 var chartMetrics = [3]metricDef{
 	{"lines", ColorPurple},
 	{"files", ColorBlue},
 	{"dirs", ColorGreen},
 }
 
-// Model é o estado da aplicação bubbletea.
+// Model holds the Bubble Tea application state.
 type Model struct {
 	history     []Stats
 	current     Stats
@@ -50,10 +50,10 @@ type Model struct {
 	chartMode   ChartMode
 	intervals   []time.Duration
 	intervalIdx int
-	metricIdx   int // index in chartMetrics; ignored in multi mode
+	metricIdx   int // Index in chartMetrics; ignored in multi mode.
 }
 
-// interval retorna o intervalo de atualização atual, com fallback seguro.
+// interval returns the current refresh interval with a safe fallback.
 func (m Model) interval() time.Duration {
 	if len(m.intervals) == 0 {
 		return time.Second
@@ -61,7 +61,7 @@ func (m Model) interval() time.Duration {
 	return m.intervals[m.intervalIdx]
 }
 
-// metricValues extrai do histórico os valores da métrica atualmente selecionada.
+// metricValues extracts the currently selected metric values from the history.
 func (m Model) metricValues() []int {
 	vals := make([]int, len(m.history))
 	for i, s := range m.history {
@@ -77,7 +77,7 @@ func (m Model) metricValues() []int {
 	return vals
 }
 
-// formatInterval formata uma duração como "1s", "30s", "1m", "5m".
+// formatInterval formats a duration as "1s", "30s", "1m", or "5m".
 func formatInterval(d time.Duration) string {
 	s := int(d.Seconds())
 	if s < 60 {
@@ -86,26 +86,26 @@ func formatInterval(d time.Duration) string {
 	return fmt.Sprintf("%dm", s/60)
 }
 
-// Init dispara a primeira varredura imediatamente, sem esperar 1 segundo.
+// Init triggers the first scan immediately instead of waiting one second.
 func (m Model) Init() tea.Cmd {
 	return scanCmd(m.cwd, m.scanOpts)
 }
 
-// scanCmd retorna um tea.Cmd que executa a varredura no path especificado.
+// scanCmd returns a tea.Cmd that scans the specified path.
 func scanCmd(path string, opts ScanOptions) tea.Cmd {
 	return func() tea.Msg {
 		return ScanMsg(Scan(path, opts))
 	}
 }
 
-// tickCmd agenda um tick após a duração especificada.
+// tickCmd schedules a tick after the specified duration.
 func tickCmd(d time.Duration) tea.Cmd {
 	return tea.Tick(d, func(t time.Time) tea.Msg {
 		return tickMsg(t)
 	})
 }
 
-// Update processa mensagens e atualiza o estado.
+// Update processes messages and updates the state.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tickMsg:
@@ -145,7 +145,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// View renderiza o dashboard completo.
+// View renders the full dashboard.
 func (m Model) View() string {
 	if m.width < 40 || m.height < 10 {
 		return lipgloss.Place(m.width, m.height,
@@ -156,7 +156,7 @@ func (m Model) View() string {
 
 	var sb strings.Builder
 
-	// --- Linha de status ---
+	// --- Status line ---
 	indicator := StyleGray.Render(fmt.Sprintf("↺ %s [i]", formatInterval(m.interval())))
 	if m.current.Scanning {
 		indicator = StyleOrange.Render("↺ scanning...")
@@ -168,11 +168,11 @@ func (m Model) View() string {
 	sb.WriteString(statusLine)
 	sb.WriteString("\n")
 
-	// --- Métricas inline ---
-	// A métrica ativa no gráfico (single-metric) é destacada com sua própria cor no label.
+	// --- Inline metrics ---
+	// The active single-metric chart entry is highlighted in its own color.
 	active := m.metricIdx
 	if m.chartMode == ChartMultiLine {
-		active = -1 // nenhuma destacada individualmente no modo multi
+		active = -1 // No individually highlighted metric in multi mode.
 	}
 	labelFiles := StyleGray.Render("files")
 	labelDirs := StyleGray.Render("│  dirs")
@@ -195,27 +195,27 @@ func (m Model) View() string {
 	sb.WriteString(metricsLine)
 	sb.WriteString("\n")
 
-	// --- Separador ---
+	// --- Separator ---
 	sb.WriteString(StyleGray.Render(strings.Repeat("─", m.width)))
 	sb.WriteString("\n")
 
-	// --- Histórico / Gráfico ---
+	// --- History / Chart ---
 	metricHint := fmt.Sprintf("  [m: %s]", chartMetrics[m.metricIdx].name)
 	if m.chartMode == ChartMultiLine {
-		metricHint = "" // multi mode shows all three, hint does not apply
+		metricHint = "" // Multi mode shows all three metrics, so the hint does not apply.
 	}
 	histLabel := fmt.Sprintf(" HISTORY  [c: %s]%s", m.chartMode.Name(), metricHint)
 	sb.WriteString(StyleGray.Render(histLabel))
 	sb.WriteString("\n")
 
-	// Calcular linhas de extensões (limitado ao espaço disponível)
+	// Calculate extension rows, limited by the available space.
 	extCount := len(m.current.ByExt)
-	extRows := (extCount + 1) / 2 // 2 colunas por linha
+	extRows := (extCount + 1) / 2 // 2 columns per row
 	if extRows < 1 {
 		extRows = 1
 	}
 
-	// Overhead fixo: status(1) + metrics(1) + sep(1) + HISTÓRICO(1) + \n pós-chart(1) + sep(1) + EXTENSÕES(1) = 7
+	// Fixed overhead: status(1) + metrics(1) + sep(1) + HISTORY(1) + \n after chart(1) + sep(1) + EXTENSIONS(1) = 7
 	const fixedOverhead = 7
 	chartHeight := m.height - fixedOverhead - extRows
 	if chartHeight < 5 {
@@ -248,11 +248,11 @@ func (m Model) View() string {
 	sb.WriteString(chartStr)
 	sb.WriteString("\n")
 
-	// --- Separador ---
+	// --- Separator ---
 	sb.WriteString(StyleGray.Render(strings.Repeat("─", m.width)))
 	sb.WriteString("\n")
 
-	// --- Extensões ---
+	// --- Extensions ---
 	sb.WriteString(StyleGray.Render(" EXTENSIONS"))
 	sb.WriteString("\n")
 	sb.WriteString(renderExtensions(m.current.ByExt, m.width))
@@ -260,13 +260,13 @@ func (m Model) View() string {
 	return sb.String()
 }
 
-// extEntry representa uma entrada de extensão para ordenação.
+// extEntry represents an extension entry for sorting.
 type extEntry struct {
 	name  string
 	lines int
 }
 
-// renderExtensions renderiza o grid de extensões em 2 colunas.
+// renderExtensions renders the extension grid in 2 columns.
 func renderExtensions(byExt map[string]int, width int) string {
 	if len(byExt) == 0 {
 		return ""
@@ -310,7 +310,7 @@ func renderExtensions(byExt map[string]int, width int) string {
 	return sb.String()
 }
 
-// formatExtEntry formata uma entrada de extensão para uma coluna.
+// formatExtEntry formats an extension entry for a column.
 func formatExtEntry(e extEntry, colWidth, countWidth int) string {
 	nameWidth := colWidth - countWidth - 1
 
@@ -326,7 +326,7 @@ func formatExtEntry(e extEntry, colWidth, countWidth int) string {
 	return nameStr + countStr
 }
 
-// formatNumber formata um inteiro com separador de milhar pt-BR (".").
+// formatNumber formats an integer with a pt-BR thousands separator (".").
 func formatNumber(n int) string {
 	s := fmt.Sprintf("%d", n)
 	if len(s) <= 3 {

--- a/scanner.go
+++ b/scanner.go
@@ -11,6 +11,96 @@ import (
 	"time"
 )
 
+// DefaultDevIgnoreDirs lista nomes de diretórios gerados, externos ou locais
+// que devem ser ignorados quando a CLI roda com --dev.
+var DefaultDevIgnoreDirs = []string{
+	".angular",
+	".cache",
+	".cxx",
+	".classpath",
+	".direnv",
+	".dart_tool",
+	".gradle",
+	".hg",
+	".idea",
+	".mvn",
+	".m2",
+	".mypy_cache",
+	".next",
+	".nox",
+	".npm",
+	".nuxt",
+	".parcel-cache",
+	".pnpm-store",
+	".project",
+	".pytest_cache",
+	".ruff_cache",
+	".settings",
+	".svelte-kit",
+	".svn",
+	".stack-work",
+	".terraform",
+	".tox",
+	".turbo",
+	".venv",
+	".vite",
+	".vs",
+	".vscode",
+	".yarn",
+	"_build",
+	"__pycache__",
+	"CMakeFiles",
+	"DerivedData",
+	"Pods",
+	"bin",
+	"build",
+	"coverage",
+	"cmake-build-debug",
+	"cmake-build-release",
+	"deps",
+	"dist",
+	"log",
+	"logs",
+	"node_modules",
+	"obj",
+	"out",
+	"site",
+	"target",
+	"temp",
+	"tmp",
+	"vendor",
+	"venv",
+}
+
+// DefaultDevIgnoreFiles lista arquivos ou padrões de arquivo gerados/local-only
+// que devem ser ignorados quando a CLI roda com --dev.
+var DefaultDevIgnoreFiles = []string{
+	".DS_Store",
+	".flutter-plugins",
+	".flutter-plugins-dependencies",
+}
+
+// DefaultDevIgnoreExts lista extensões geradas que devem ser ignoradas com --dev.
+var DefaultDevIgnoreExts = []string{
+	".class",
+	".dll",
+	".dylib",
+	".exe",
+	".iml",
+	".o",
+	".obj",
+	".pyd",
+	".pyc",
+	".pyo",
+	".so",
+	".test",
+}
+
+// ScanOptions controla regras adicionais de varredura.
+type ScanOptions struct {
+	DevMode bool
+}
+
 // Stats contém as métricas coletadas de uma varredura.
 type Stats struct {
 	Files    int
@@ -26,7 +116,7 @@ type ScanMsg Stats
 // Scan percorre o diretório path e retorna as métricas coletadas.
 // A varredura tem timeout de 5 segundos; se expirar, retorna dados parciais
 // com Stats.Scanning = true.
-func Scan(path string) Stats {
+func Scan(path string, opts ScanOptions) Stats {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -52,6 +142,13 @@ func Scan(path string) Stats {
 
 		// Ignorar entradas ocultas
 		if strings.HasPrefix(name, ".") {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if shouldIgnoreEntry(name, d.IsDir(), opts) {
 			if d.IsDir() {
 				return filepath.SkipDir
 			}
@@ -95,6 +192,36 @@ func Scan(path string) Stats {
 	})
 
 	return stats
+}
+
+func shouldIgnoreEntry(name string, isDir bool, opts ScanOptions) bool {
+	if !opts.DevMode {
+		return false
+	}
+
+	if isDir {
+		return containsName(DefaultDevIgnoreDirs, name)
+	}
+
+	if containsName(DefaultDevIgnoreFiles, name) {
+		return true
+	}
+
+	ext := filepath.Ext(name)
+	if ext != "" && containsName(DefaultDevIgnoreExts, ext) {
+		return true
+	}
+
+	return strings.HasSuffix(name, ".min.js.map")
+}
+
+func containsName(names []string, target string) bool {
+	for _, name := range names {
+		if name == target {
+			return true
+		}
+	}
+	return false
 }
 
 // isTextFile retorna true se o arquivo não contiver byte nulo nos primeiros 512 bytes.

--- a/scanner.go
+++ b/scanner.go
@@ -98,7 +98,8 @@ var DefaultDevIgnoreExts = []string{
 
 // ScanOptions controls additional scan rules.
 type ScanOptions struct {
-	DevMode bool
+	DevMode    bool
+	IgnoreDirs []string
 }
 
 // Stats contains the metrics collected from a scan.
@@ -195,12 +196,12 @@ func Scan(path string, opts ScanOptions) Stats {
 }
 
 func shouldIgnoreEntry(name string, isDir bool, opts ScanOptions) bool {
-	if !opts.DevMode {
-		return false
+	if isDir {
+		return shouldIgnoreDir(name, opts)
 	}
 
-	if isDir {
-		return containsName(DefaultDevIgnoreDirs, name)
+	if !opts.DevMode {
+		return false
 	}
 
 	if containsName(DefaultDevIgnoreFiles, name) {
@@ -213,6 +214,16 @@ func shouldIgnoreEntry(name string, isDir bool, opts ScanOptions) bool {
 	}
 
 	return strings.HasSuffix(name, ".min.js.map")
+}
+
+func shouldIgnoreDir(name string, opts ScanOptions) bool {
+	if containsName(opts.IgnoreDirs, name) {
+		return true
+	}
+	if !opts.DevMode {
+		return false
+	}
+	return containsName(DefaultDevIgnoreDirs, name)
 }
 
 func containsName(names []string, target string) bool {

--- a/scanner.go
+++ b/scanner.go
@@ -13,40 +13,9 @@ import (
 
 // DefaultDevIgnoreDirs lists generated, external, or local-only directories
 // that should be ignored when the CLI runs with --dev.
+// Note: hidden directories (prefixed with ".") are already skipped by the
+// scanner, so they do not need to appear here.
 var DefaultDevIgnoreDirs = []string{
-	".angular",
-	".cache",
-	".cxx",
-	".classpath",
-	".direnv",
-	".dart_tool",
-	".gradle",
-	".hg",
-	".idea",
-	".mvn",
-	".m2",
-	".mypy_cache",
-	".next",
-	".nox",
-	".npm",
-	".nuxt",
-	".parcel-cache",
-	".pnpm-store",
-	".project",
-	".pytest_cache",
-	".ruff_cache",
-	".settings",
-	".svelte-kit",
-	".svn",
-	".stack-work",
-	".terraform",
-	".tox",
-	".turbo",
-	".venv",
-	".vite",
-	".vs",
-	".vscode",
-	".yarn",
 	"_build",
 	"__pycache__",
 	"CMakeFiles",
@@ -70,14 +39,6 @@ var DefaultDevIgnoreDirs = []string{
 	"tmp",
 	"vendor",
 	"venv",
-}
-
-// DefaultDevIgnoreFiles lists generated or local-only file names
-// that should be ignored when the CLI runs with --dev.
-var DefaultDevIgnoreFiles = []string{
-	".DS_Store",
-	".flutter-plugins",
-	".flutter-plugins-dependencies",
 }
 
 // DefaultDevIgnoreExts lists generated file extensions that should be ignored with --dev.
@@ -202,10 +163,6 @@ func shouldIgnoreEntry(name string, isDir bool, opts ScanOptions) bool {
 
 	if !opts.DevMode {
 		return false
-	}
-
-	if containsName(DefaultDevIgnoreFiles, name) {
-		return true
 	}
 
 	ext := filepath.Ext(name)

--- a/scanner.go
+++ b/scanner.go
@@ -11,8 +11,8 @@ import (
 	"time"
 )
 
-// DefaultDevIgnoreDirs lista nomes de diretórios gerados, externos ou locais
-// que devem ser ignorados quando a CLI roda com --dev.
+// DefaultDevIgnoreDirs lists generated, external, or local-only directories
+// that should be ignored when the CLI runs with --dev.
 var DefaultDevIgnoreDirs = []string{
 	".angular",
 	".cache",
@@ -72,15 +72,15 @@ var DefaultDevIgnoreDirs = []string{
 	"venv",
 }
 
-// DefaultDevIgnoreFiles lista arquivos ou padrões de arquivo gerados/local-only
-// que devem ser ignorados quando a CLI roda com --dev.
+// DefaultDevIgnoreFiles lists generated or local-only file names
+// that should be ignored when the CLI runs with --dev.
 var DefaultDevIgnoreFiles = []string{
 	".DS_Store",
 	".flutter-plugins",
 	".flutter-plugins-dependencies",
 }
 
-// DefaultDevIgnoreExts lista extensões geradas que devem ser ignoradas com --dev.
+// DefaultDevIgnoreExts lists generated file extensions that should be ignored with --dev.
 var DefaultDevIgnoreExts = []string{
 	".class",
 	".dll",
@@ -96,26 +96,26 @@ var DefaultDevIgnoreExts = []string{
 	".test",
 }
 
-// ScanOptions controla regras adicionais de varredura.
+// ScanOptions controls additional scan rules.
 type ScanOptions struct {
 	DevMode bool
 }
 
-// Stats contém as métricas coletadas de uma varredura.
+// Stats contains the metrics collected from a scan.
 type Stats struct {
 	Files    int
 	Dirs     int
 	Lines    int
-	ByExt    map[string]int // ".go" → linhas; "(no ext)" para sem extensão
-	Scanning bool           // true se varredura foi interrompida por timeout
+	ByExt    map[string]int // ".go" -> lines; "(no ext)" for files without an extension
+	Scanning bool           // true if the scan was interrupted by timeout
 }
 
-// ScanMsg é enviada ao modelo bubbletea após uma varredura.
+// ScanMsg is sent to the Bubble Tea model after a scan completes.
 type ScanMsg Stats
 
-// Scan percorre o diretório path e retorna as métricas coletadas.
-// A varredura tem timeout de 5 segundos; se expirar, retorna dados parciais
-// com Stats.Scanning = true.
+// Scan walks the given path and returns the collected metrics.
+// The scan has a 5-second timeout; if it expires, it returns partial data
+// with Stats.Scanning = true.
 func Scan(path string, opts ScanOptions) Stats {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -125,7 +125,7 @@ func Scan(path string, opts ScanOptions) Stats {
 	}
 
 	filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
-		// Verificar timeout
+		// Check for timeout.
 		select {
 		case <-ctx.Done():
 			stats.Scanning = true
@@ -133,14 +133,14 @@ func Scan(path string, opts ScanOptions) Stats {
 		default:
 		}
 
-		// Silenciar todos os erros de I/O
+		// Silence all I/O errors.
 		if err != nil {
 			return nil
 		}
 
 		name := d.Name()
 
-		// Ignorar entradas ocultas
+		// Ignore hidden entries.
 		if strings.HasPrefix(name, ".") {
 			if d.IsDir() {
 				return filepath.SkipDir
@@ -155,20 +155,20 @@ func Scan(path string, opts ScanOptions) Stats {
 			return nil
 		}
 
-		// Ignorar symlinks
+		// Ignore symlinks.
 		if d.Type()&fs.ModeSymlink != 0 {
 			return nil
 		}
 
 		if d.IsDir() {
-			// Não contar o diretório raiz
+			// Do not count the root directory.
 			if p != path {
 				stats.Dirs++
 			}
 			return nil
 		}
 
-		// É um arquivo regular
+		// Regular file.
 		stats.Files++
 
 		ext := filepath.Ext(name)
@@ -176,13 +176,13 @@ func Scan(path string, opts ScanOptions) Stats {
 			ext = "(no ext)"
 		}
 
-		// Detectar se é texto
+		// Detect whether the file is text.
 		if isTextFile(p) {
 			lines := countLines(ctx, p)
 			stats.Lines += lines
 			stats.ByExt[ext] += lines
 		} else {
-			// Arquivo binário: conta no mapa com 0 linhas (garante chave presente)
+			// Binary file: keep the extension in the map with 0 lines.
 			if _, ok := stats.ByExt[ext]; !ok {
 				stats.ByExt[ext] = 0
 			}
@@ -224,7 +224,7 @@ func containsName(names []string, target string) bool {
 	return false
 }
 
-// isTextFile retorna true se o arquivo não contiver byte nulo nos primeiros 512 bytes.
+// isTextFile returns true if the file does not contain a NUL byte in the first 512 bytes.
 func isTextFile(path string) bool {
 	f, err := os.Open(path)
 	if err != nil {
@@ -247,7 +247,7 @@ func isTextFile(path string) bool {
 	return true
 }
 
-// countLines conta o número de linhas de um arquivo texto.
+// countLines counts the number of lines in a text file.
 func countLines(ctx context.Context, path string) int {
 	f, err := os.Open(path)
 	if err != nil {

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -122,26 +122,26 @@ func TestScan_DevModeIgnoresCommonDependencyAndIDEDirs(t *testing.T) {
 
 	nodeModules := filepath.Join(dir, "node_modules")
 	if err := os.Mkdir(nodeModules, 0755); err != nil {
-			t.Fatalf("failed to create node_modules: %v", err)
+		t.Fatalf("failed to create node_modules: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(nodeModules, "index.js"), []byte("console.log('x')\n"), 0644); err != nil {
-			t.Fatalf("failed to create file in node_modules: %v", err)
+		t.Fatalf("failed to create file in node_modules: %v", err)
 	}
 
 	ideaDir := filepath.Join(dir, ".idea")
 	if err := os.Mkdir(ideaDir, 0755); err != nil {
-			t.Fatalf("failed to create .idea: %v", err)
+		t.Fatalf("failed to create .idea: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(ideaDir, "workspace.xml"), []byte("<project />\n"), 0644); err != nil {
-			t.Fatalf("failed to create file in .idea: %v", err)
+		t.Fatalf("failed to create file in .idea: %v", err)
 	}
 
 	srcDir := filepath.Join(dir, "src")
 	if err := os.Mkdir(srcDir, 0755); err != nil {
-			t.Fatalf("failed to create src: %v", err)
+		t.Fatalf("failed to create src: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "main.ts"), []byte("const answer = 42\n"), 0644); err != nil {
-			t.Fatalf("failed to create file in src: %v", err)
+		t.Fatalf("failed to create file in src: %v", err)
 	}
 
 	stats := Scan(dir, ScanOptions{DevMode: true})
@@ -168,10 +168,10 @@ func TestScan_DevModeIgnoresGeneratedFilesAcrossEcosystems(t *testing.T) {
 
 	srcDir := filepath.Join(dir, "src")
 	if err := os.Mkdir(srcDir, 0755); err != nil {
-			t.Fatalf("failed to create src: %v", err)
+		t.Fatalf("failed to create src: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package main\n"), 0644); err != nil {
-			t.Fatalf("failed to create main.go: %v", err)
+		t.Fatalf("failed to create main.go: %v", err)
 	}
 
 	generatedFiles := []string{
@@ -213,10 +213,10 @@ func TestScan_DevModeDoesNotIgnoreCommonDirsWhenDisabled(t *testing.T) {
 
 	targetDir := filepath.Join(dir, "target")
 	if err := os.Mkdir(targetDir, 0755); err != nil {
-			t.Fatalf("failed to create target: %v", err)
+		t.Fatalf("failed to create target: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(targetDir, "app.jar"), []byte("jar-content\n"), 0644); err != nil {
-			t.Fatalf("failed to create app.jar: %v", err)
+		t.Fatalf("failed to create app.jar: %v", err)
 	}
 
 	stats := Scan(dir, ScanOptions{})
@@ -262,5 +262,86 @@ func TestScan_DevModeDoesNotIgnoreProjectConfigFiles(t *testing.T) {
 	}
 	if got := stats.ByExt[".toml"]; got == 0 {
 		t.Error(".toml project config should not be ignored with --dev")
+	}
+}
+
+func TestScan_IgnoresCustomDirsFromOptions(t *testing.T) {
+	dir := t.TempDir()
+
+	cacheDir := filepath.Join(dir, "cache-data")
+	if err := os.Mkdir(cacheDir, 0755); err != nil {
+		t.Fatalf("failed to create cache-data: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "snapshot.json"), []byte("{\"ok\":true}\n"), 0644); err != nil {
+		t.Fatalf("failed to create file in cache-data: %v", err)
+	}
+
+	srcDir := filepath.Join(dir, "src")
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatalf("failed to create src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "main.ts"), []byte("const answer = 42\n"), 0644); err != nil {
+		t.Fatalf("failed to create file in src: %v", err)
+	}
+
+	stats := Scan(dir, ScanOptions{IgnoreDirs: []string{"cache-data"}})
+
+	if stats.Files != 1 {
+		t.Errorf("expected 1 file with custom ignored dirs, got %d", stats.Files)
+	}
+	if stats.Dirs != 1 {
+		t.Errorf("expected 1 directory with custom ignored dirs, got %d", stats.Dirs)
+	}
+	if got := stats.ByExt[".ts"]; got != 1 {
+		t.Errorf("expected .ts=1 with custom ignored dirs, got %d", got)
+	}
+	if _, ok := stats.ByExt[".json"]; ok {
+		t.Error(".json from a custom ignored directory should not appear in ByExt")
+	}
+}
+
+func TestScan_CombinesDevModeAndCustomIgnoredDirs(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.Mkdir(filepath.Join(dir, "node_modules"), 0755); err != nil {
+		t.Fatalf("failed to create node_modules: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "node_modules", "index.js"), []byte("console.log('x')\n"), 0644); err != nil {
+		t.Fatalf("failed to create file in node_modules: %v", err)
+	}
+
+	if err := os.Mkdir(filepath.Join(dir, "generated"), 0755); err != nil {
+		t.Fatalf("failed to create generated: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "generated", "api.ts"), []byte("export const x = 1\n"), 0644); err != nil {
+		t.Fatalf("failed to create file in generated: %v", err)
+	}
+
+	if err := os.Mkdir(filepath.Join(dir, "src"), 0755); err != nil {
+		t.Fatalf("failed to create src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "src", "main.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("failed to create file in src: %v", err)
+	}
+
+	stats := Scan(dir, ScanOptions{
+		DevMode:    true,
+		IgnoreDirs: []string{"generated"},
+	})
+
+	if stats.Files != 1 {
+		t.Errorf("expected 1 file with dev mode plus custom ignored dirs, got %d", stats.Files)
+	}
+	if stats.Dirs != 1 {
+		t.Errorf("expected 1 directory with dev mode plus custom ignored dirs, got %d", stats.Dirs)
+	}
+	if got := stats.ByExt[".go"]; got != 1 {
+		t.Errorf("expected .go=1 with dev mode plus custom ignored dirs, got %d", got)
+	}
+	if _, ok := stats.ByExt[".ts"]; ok {
+		t.Error(".ts from a custom ignored directory should not appear in ByExt")
+	}
+	if _, ok := stats.ByExt[".js"]; ok {
+		t.Error(".js from node_modules should not appear in ByExt")
 	}
 }

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -8,29 +8,29 @@ import (
 	"testing"
 )
 
-// createTestDir cria um diretório temporário com arquivos para testar.
+// createTestDir creates a temporary directory with files for testing.
 func createTestDir(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 
-	// Arquivo Go com 3 linhas
+	// Go file with 3 lines.
 	os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0644)
 
-	// Arquivo markdown com 3 linhas
+	// Markdown file with 3 lines.
 	os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Título\n\nTexto\n"), 0644)
 
-	// Arquivo sem extensão com 1 linha
+	// File without an extension with 1 line.
 	os.WriteFile(filepath.Join(dir, "Makefile"), []byte("build:\n"), 0644)
 
-	// Subdiretório normal
+	// Regular subdirectory.
 	subDir := filepath.Join(dir, "pkg")
 	os.Mkdir(subDir, 0755)
 	os.WriteFile(filepath.Join(subDir, "util.go"), []byte("package pkg\n"), 0644)
 
-	// Arquivo binário (contém byte nulo)
+	// Binary file with a NUL byte.
 	os.WriteFile(filepath.Join(dir, "binary.bin"), []byte{0x00, 0x01, 0x02}, 0644)
 
-	// Diretório oculto (deve ser ignorado)
+	// Hidden directory that should be ignored.
 	hiddenDir := filepath.Join(dir, ".git")
 	os.Mkdir(hiddenDir, 0755)
 	os.WriteFile(filepath.Join(hiddenDir, "config"), []byte("ignored\n"), 0644)
@@ -42,12 +42,12 @@ func TestScan_CountsFilesAndDirs(t *testing.T) {
 	dir := createTestDir(t)
 	stats := Scan(dir, ScanOptions{})
 
-	// main.go, README.md, Makefile, binary.bin, pkg/util.go = 5 arquivos
+	// main.go, README.md, Makefile, binary.bin, pkg/util.go = 5 files.
 	if stats.Files != 5 {
 		t.Errorf("esperado 5 arquivos, obtido %d", stats.Files)
 	}
 
-	// pkg/ = 1 diretório (ocultos ignorados)
+	// pkg/ = 1 directory, with hidden entries ignored.
 	if stats.Dirs != 1 {
 		t.Errorf("esperado 1 diretório, obtido %d", stats.Dirs)
 	}
@@ -57,7 +57,7 @@ func TestScan_CountsLines(t *testing.T) {
 	dir := createTestDir(t)
 	stats := Scan(dir, ScanOptions{})
 
-	// main.go=3, README.md=3, Makefile=1, pkg/util.go=1, binary.bin=0 → 8 linhas
+	// main.go=3, README.md=3, Makefile=1, pkg/util.go=1, binary.bin=0 -> 8 lines.
 	if stats.Lines != 8 {
 		t.Errorf("esperado 8 linhas, obtido %d", stats.Lines)
 	}
@@ -67,17 +67,17 @@ func TestScan_GroupsByExtension(t *testing.T) {
 	dir := createTestDir(t)
 	stats := Scan(dir, ScanOptions{})
 
-	// .go: main.go(3) + pkg/util.go(1) = 4
+	// .go: main.go(3) + pkg/util.go(1) = 4.
 	if stats.ByExt[".go"] != 4 {
 		t.Errorf("esperado .go=4, obtido %d", stats.ByExt[".go"])
 	}
 
-	// .md: README.md(3)
+	// .md: README.md(3).
 	if stats.ByExt[".md"] != 3 {
 		t.Errorf("esperado .md=3, obtido %d", stats.ByExt[".md"])
 	}
 
-	// sem ext: Makefile(1)
+	// No extension: Makefile(1).
 	if stats.ByExt["(no ext)"] != 1 {
 		t.Errorf("esperado (sem ext)=1, obtido %d", stats.ByExt["(no ext)"])
 	}
@@ -87,7 +87,7 @@ func TestScan_IgnoresHiddenEntries(t *testing.T) {
 	dir := createTestDir(t)
 	stats := Scan(dir, ScanOptions{})
 
-	// .git não deve aparecer em ByExt
+	// .git should not appear in ByExt.
 	for k := range stats.ByExt {
 		if strings.Contains(k, "git") {
 			t.Errorf("extensão inesperada encontrada: %s", k)
@@ -122,44 +122,44 @@ func TestScan_DevModeIgnoresCommonDependencyAndIDEDirs(t *testing.T) {
 
 	nodeModules := filepath.Join(dir, "node_modules")
 	if err := os.Mkdir(nodeModules, 0755); err != nil {
-		t.Fatalf("erro ao criar node_modules: %v", err)
+			t.Fatalf("failed to create node_modules: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(nodeModules, "index.js"), []byte("console.log('x')\n"), 0644); err != nil {
-		t.Fatalf("erro ao criar arquivo em node_modules: %v", err)
+			t.Fatalf("failed to create file in node_modules: %v", err)
 	}
 
 	ideaDir := filepath.Join(dir, ".idea")
 	if err := os.Mkdir(ideaDir, 0755); err != nil {
-		t.Fatalf("erro ao criar .idea: %v", err)
+			t.Fatalf("failed to create .idea: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(ideaDir, "workspace.xml"), []byte("<project />\n"), 0644); err != nil {
-		t.Fatalf("erro ao criar arquivo em .idea: %v", err)
+			t.Fatalf("failed to create file in .idea: %v", err)
 	}
 
 	srcDir := filepath.Join(dir, "src")
 	if err := os.Mkdir(srcDir, 0755); err != nil {
-		t.Fatalf("erro ao criar src: %v", err)
+			t.Fatalf("failed to create src: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "main.ts"), []byte("const answer = 42\n"), 0644); err != nil {
-		t.Fatalf("erro ao criar arquivo em src: %v", err)
+			t.Fatalf("failed to create file in src: %v", err)
 	}
 
 	stats := Scan(dir, ScanOptions{DevMode: true})
 
 	if stats.Files != 1 {
-		t.Errorf("esperado 1 arquivo com --dev, obtido %d", stats.Files)
+		t.Errorf("expected 1 file with --dev, got %d", stats.Files)
 	}
 	if stats.Dirs != 1 {
-		t.Errorf("esperado 1 diretório com --dev, obtido %d", stats.Dirs)
+		t.Errorf("expected 1 directory with --dev, got %d", stats.Dirs)
 	}
 	if stats.Lines != 1 {
-		t.Errorf("esperado 1 linha com --dev, obtido %d", stats.Lines)
+		t.Errorf("expected 1 line with --dev, got %d", stats.Lines)
 	}
 	if got := stats.ByExt[".ts"]; got != 1 {
-		t.Errorf("esperado .ts=1 com --dev, obtido %d", got)
+		t.Errorf("expected .ts=1 with --dev, got %d", got)
 	}
 	if _, ok := stats.ByExt[".js"]; ok {
-		t.Error(".js de node_modules não deve aparecer em ByExt com --dev")
+		t.Error(".js from node_modules should not appear in ByExt with --dev")
 	}
 }
 
@@ -168,10 +168,10 @@ func TestScan_DevModeIgnoresGeneratedFilesAcrossEcosystems(t *testing.T) {
 
 	srcDir := filepath.Join(dir, "src")
 	if err := os.Mkdir(srcDir, 0755); err != nil {
-		t.Fatalf("erro ao criar src: %v", err)
+			t.Fatalf("failed to create src: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package main\n"), 0644); err != nil {
-		t.Fatalf("erro ao criar main.go: %v", err)
+			t.Fatalf("failed to create main.go: %v", err)
 	}
 
 	generatedFiles := []string{
@@ -182,29 +182,29 @@ func TestScan_DevModeIgnoresGeneratedFilesAcrossEcosystems(t *testing.T) {
 	}
 	for _, name := range generatedFiles {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte("generated\n"), 0644); err != nil {
-			t.Fatalf("erro ao criar %s: %v", name, err)
+			t.Fatalf("failed to create %s: %v", name, err)
 		}
 	}
 
 	stats := Scan(dir, ScanOptions{DevMode: true})
 
 	if stats.Files != 1 {
-		t.Errorf("esperado 1 arquivo real com --dev, obtido %d", stats.Files)
+		t.Errorf("expected 1 real file with --dev, got %d", stats.Files)
 	}
 	if got := stats.ByExt[".go"]; got != 1 {
-		t.Errorf("esperado .go=1 com --dev, obtido %d", got)
+		t.Errorf("expected .go=1 with --dev, got %d", got)
 	}
 	if _, ok := stats.ByExt[".iml"]; ok {
-		t.Error(".iml não deve aparecer em ByExt com --dev")
+		t.Error(".iml should not appear in ByExt with --dev")
 	}
 	if _, ok := stats.ByExt[".class"]; ok {
-		t.Error(".class não deve aparecer em ByExt com --dev")
+		t.Error(".class should not appear in ByExt with --dev")
 	}
 	if _, ok := stats.ByExt[".so"]; ok {
-		t.Error(".so não deve aparecer em ByExt com --dev")
+		t.Error(".so should not appear in ByExt with --dev")
 	}
 	if _, ok := stats.ByExt[".map"]; ok {
-		t.Error("*.min.js.map não deve aparecer em ByExt com --dev")
+		t.Error("*.min.js.map should not appear in ByExt with --dev")
 	}
 }
 
@@ -213,22 +213,22 @@ func TestScan_DevModeDoesNotIgnoreCommonDirsWhenDisabled(t *testing.T) {
 
 	targetDir := filepath.Join(dir, "target")
 	if err := os.Mkdir(targetDir, 0755); err != nil {
-		t.Fatalf("erro ao criar target: %v", err)
+			t.Fatalf("failed to create target: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(targetDir, "app.jar"), []byte("jar-content\n"), 0644); err != nil {
-		t.Fatalf("erro ao criar app.jar: %v", err)
+			t.Fatalf("failed to create app.jar: %v", err)
 	}
 
 	stats := Scan(dir, ScanOptions{})
 
 	if stats.Files != 1 {
-		t.Errorf("esperado 1 arquivo sem --dev, obtido %d", stats.Files)
+		t.Errorf("expected 1 file without --dev, got %d", stats.Files)
 	}
 	if stats.Dirs != 1 {
-		t.Errorf("esperado 1 diretório sem --dev, obtido %d", stats.Dirs)
+		t.Errorf("expected 1 directory without --dev, got %d", stats.Dirs)
 	}
 	if got := stats.ByExt[".jar"]; got != 1 {
-		t.Errorf("esperado .jar=1 sem --dev, obtido %d", got)
+		t.Errorf("expected .jar=1 without --dev, got %d", got)
 	}
 }
 
@@ -245,22 +245,22 @@ func TestScan_DevModeDoesNotIgnoreProjectConfigFiles(t *testing.T) {
 	}
 	for name, content := range files {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
-			t.Fatalf("erro ao criar %s: %v", name, err)
+			t.Fatalf("failed to create %s: %v", name, err)
 		}
 	}
 
 	stats := Scan(dir, ScanOptions{DevMode: true})
 
 	if stats.Files != len(files) {
-		t.Errorf("esperado %d arquivos de configuração com --dev, obtido %d", len(files), stats.Files)
+		t.Errorf("expected %d project config files with --dev, got %d", len(files), stats.Files)
 	}
 	if got := stats.ByExt[".json"]; got == 0 {
-		t.Error(".json de configuração do projeto não deve ser ignorado com --dev")
+		t.Error(".json project config should not be ignored with --dev")
 	}
 	if got := stats.ByExt[".xml"]; got == 0 {
-		t.Error(".xml de configuração do projeto não deve ser ignorado com --dev")
+		t.Error(".xml project config should not be ignored with --dev")
 	}
 	if got := stats.ByExt[".toml"]; got == 0 {
-		t.Error(".toml de configuração do projeto não deve ser ignorado com --dev")
+		t.Error(".toml project config should not be ignored with --dev")
 	}
 }

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -40,7 +40,7 @@ func createTestDir(t *testing.T) string {
 
 func TestScan_CountsFilesAndDirs(t *testing.T) {
 	dir := createTestDir(t)
-	stats := Scan(dir)
+	stats := Scan(dir, ScanOptions{})
 
 	// main.go, README.md, Makefile, binary.bin, pkg/util.go = 5 arquivos
 	if stats.Files != 5 {
@@ -55,7 +55,7 @@ func TestScan_CountsFilesAndDirs(t *testing.T) {
 
 func TestScan_CountsLines(t *testing.T) {
 	dir := createTestDir(t)
-	stats := Scan(dir)
+	stats := Scan(dir, ScanOptions{})
 
 	// main.go=3, README.md=3, Makefile=1, pkg/util.go=1, binary.bin=0 → 8 linhas
 	if stats.Lines != 8 {
@@ -65,7 +65,7 @@ func TestScan_CountsLines(t *testing.T) {
 
 func TestScan_GroupsByExtension(t *testing.T) {
 	dir := createTestDir(t)
-	stats := Scan(dir)
+	stats := Scan(dir, ScanOptions{})
 
 	// .go: main.go(3) + pkg/util.go(1) = 4
 	if stats.ByExt[".go"] != 4 {
@@ -85,7 +85,7 @@ func TestScan_GroupsByExtension(t *testing.T) {
 
 func TestScan_IgnoresHiddenEntries(t *testing.T) {
 	dir := createTestDir(t)
-	stats := Scan(dir)
+	stats := Scan(dir, ScanOptions{})
 
 	// .git não deve aparecer em ByExt
 	for k := range stats.ByExt {
@@ -97,7 +97,7 @@ func TestScan_IgnoresHiddenEntries(t *testing.T) {
 
 func TestScan_BinaryNotCountedInLines(t *testing.T) {
 	dir := createTestDir(t)
-	stats := Scan(dir)
+	stats := Scan(dir, ScanOptions{})
 
 	v, ok := stats.ByExt[".bin"]
 	if !ok {
@@ -110,9 +110,157 @@ func TestScan_BinaryNotCountedInLines(t *testing.T) {
 
 func TestScan_ScanningFalseOnSuccess(t *testing.T) {
 	dir := createTestDir(t)
-	stats := Scan(dir)
+	stats := Scan(dir, ScanOptions{})
 
 	if stats.Scanning {
 		t.Error("Scanning deve ser false para varredura concluída")
+	}
+}
+
+func TestScan_DevModeIgnoresCommonDependencyAndIDEDirs(t *testing.T) {
+	dir := t.TempDir()
+
+	nodeModules := filepath.Join(dir, "node_modules")
+	if err := os.Mkdir(nodeModules, 0755); err != nil {
+		t.Fatalf("erro ao criar node_modules: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nodeModules, "index.js"), []byte("console.log('x')\n"), 0644); err != nil {
+		t.Fatalf("erro ao criar arquivo em node_modules: %v", err)
+	}
+
+	ideaDir := filepath.Join(dir, ".idea")
+	if err := os.Mkdir(ideaDir, 0755); err != nil {
+		t.Fatalf("erro ao criar .idea: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ideaDir, "workspace.xml"), []byte("<project />\n"), 0644); err != nil {
+		t.Fatalf("erro ao criar arquivo em .idea: %v", err)
+	}
+
+	srcDir := filepath.Join(dir, "src")
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatalf("erro ao criar src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "main.ts"), []byte("const answer = 42\n"), 0644); err != nil {
+		t.Fatalf("erro ao criar arquivo em src: %v", err)
+	}
+
+	stats := Scan(dir, ScanOptions{DevMode: true})
+
+	if stats.Files != 1 {
+		t.Errorf("esperado 1 arquivo com --dev, obtido %d", stats.Files)
+	}
+	if stats.Dirs != 1 {
+		t.Errorf("esperado 1 diretório com --dev, obtido %d", stats.Dirs)
+	}
+	if stats.Lines != 1 {
+		t.Errorf("esperado 1 linha com --dev, obtido %d", stats.Lines)
+	}
+	if got := stats.ByExt[".ts"]; got != 1 {
+		t.Errorf("esperado .ts=1 com --dev, obtido %d", got)
+	}
+	if _, ok := stats.ByExt[".js"]; ok {
+		t.Error(".js de node_modules não deve aparecer em ByExt com --dev")
+	}
+}
+
+func TestScan_DevModeIgnoresGeneratedFilesAcrossEcosystems(t *testing.T) {
+	dir := t.TempDir()
+
+	srcDir := filepath.Join(dir, "src")
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatalf("erro ao criar src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("erro ao criar main.go: %v", err)
+	}
+
+	generatedFiles := []string{
+		"App.iml",
+		"Main.class",
+		"native.so",
+		"bundle.min.js.map",
+	}
+	for _, name := range generatedFiles {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("generated\n"), 0644); err != nil {
+			t.Fatalf("erro ao criar %s: %v", name, err)
+		}
+	}
+
+	stats := Scan(dir, ScanOptions{DevMode: true})
+
+	if stats.Files != 1 {
+		t.Errorf("esperado 1 arquivo real com --dev, obtido %d", stats.Files)
+	}
+	if got := stats.ByExt[".go"]; got != 1 {
+		t.Errorf("esperado .go=1 com --dev, obtido %d", got)
+	}
+	if _, ok := stats.ByExt[".iml"]; ok {
+		t.Error(".iml não deve aparecer em ByExt com --dev")
+	}
+	if _, ok := stats.ByExt[".class"]; ok {
+		t.Error(".class não deve aparecer em ByExt com --dev")
+	}
+	if _, ok := stats.ByExt[".so"]; ok {
+		t.Error(".so não deve aparecer em ByExt com --dev")
+	}
+	if _, ok := stats.ByExt[".map"]; ok {
+		t.Error("*.min.js.map não deve aparecer em ByExt com --dev")
+	}
+}
+
+func TestScan_DevModeDoesNotIgnoreCommonDirsWhenDisabled(t *testing.T) {
+	dir := t.TempDir()
+
+	targetDir := filepath.Join(dir, "target")
+	if err := os.Mkdir(targetDir, 0755); err != nil {
+		t.Fatalf("erro ao criar target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, "app.jar"), []byte("jar-content\n"), 0644); err != nil {
+		t.Fatalf("erro ao criar app.jar: %v", err)
+	}
+
+	stats := Scan(dir, ScanOptions{})
+
+	if stats.Files != 1 {
+		t.Errorf("esperado 1 arquivo sem --dev, obtido %d", stats.Files)
+	}
+	if stats.Dirs != 1 {
+		t.Errorf("esperado 1 diretório sem --dev, obtido %d", stats.Dirs)
+	}
+	if got := stats.ByExt[".jar"]; got != 1 {
+		t.Errorf("esperado .jar=1 sem --dev, obtido %d", got)
+	}
+}
+
+func TestScan_DevModeDoesNotIgnoreProjectConfigFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	files := map[string]string{
+		"package.json":     "{\n  \"name\": \"app\"\n}\n",
+		"pom.xml":          "<project></project>\n",
+		"build.gradle.kts": "plugins {}\n",
+		"tsconfig.json":    "{\n  \"compilerOptions\": {}\n}\n",
+		"pyproject.toml":   "[project]\nname = \"app\"\n",
+		"Cargo.toml":       "[package]\nname = \"app\"\n",
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("erro ao criar %s: %v", name, err)
+		}
+	}
+
+	stats := Scan(dir, ScanOptions{DevMode: true})
+
+	if stats.Files != len(files) {
+		t.Errorf("esperado %d arquivos de configuração com --dev, obtido %d", len(files), stats.Files)
+	}
+	if got := stats.ByExt[".json"]; got == 0 {
+		t.Error(".json de configuração do projeto não deve ser ignorado com --dev")
+	}
+	if got := stats.ByExt[".xml"]; got == 0 {
+		t.Error(".xml de configuração do projeto não deve ser ignorado com --dev")
+	}
+	if got := stats.ByExt[".toml"]; got == 0 {
+		t.Error(".toml de configuração do projeto não deve ser ignorado com --dev")
 	}
 }

--- a/styles.go
+++ b/styles.go
@@ -4,12 +4,12 @@ package main
 import "github.com/charmbracelet/lipgloss"
 
 const (
-	ColorBlue       = "#58a6ff" // valor arquivos, labels extensão
-	ColorGreen      = "#3fb950" // valor pastas
-	ColorPurple     = "#d2a8ff" // valor linhas totais, linha do gráfico
-	ColorPurpleDark = "#3d1f5c" // área preenchida do gráfico
-	ColorGray       = "#8b949e" // labels, eixos, indicador ↺ 1s
-	ColorOrange     = "#e3b341" // indicador ↺ scanning…
+	ColorBlue       = "#58a6ff" // File values and extension labels.
+	ColorGreen      = "#3fb950" // Directory values.
+	ColorPurple     = "#d2a8ff" // Total line counts and chart line.
+	ColorPurpleDark = "#3d1f5c" // Filled chart area.
+	ColorGray       = "#8b949e" // Labels, axes, and the ↺ 1s indicator.
+	ColorOrange     = "#e3b341" // The ↺ scanning… indicator.
 )
 
 var (


### PR DESCRIPTION
## Summary
- add a new --dev flag to enable scan-time ignore rules for development-only paths
- ignore common dependency, build, cache, IDE, VCS directories and generated files across multiple ecosystems
- document the new behavior and add test coverage for dev-mode filtering while keeping project config files counted

## Testing
- GOCACHE=/tmp/go-build GOTMPDIR=/tmp/go-tmp go test ./...