### PR TITLE
Add auto-tag workflow on merge to main

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,76 @@
+name: Auto Tag
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create version tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: latest
+        run: |
+          tag=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          echo "tag=${tag:-v0.0.0}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine bump type
+        id: bump
+        run: |
+          latest="${{ steps.latest.outputs.tag }}"
+          # Get commits since last tag
+          log=$(git log "${latest}..HEAD" --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
+
+          if echo "$log" | grep -qiE '^breaking|^BREAKING CHANGE|!:'; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif echo "$log" | grep -qiE '^feat'; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute next version
+        id: next
+        run: |
+          latest="${{ steps.latest.outputs.tag }}"
+          bump="${{ steps.bump.outputs.type }}"
+
+          # Strip leading v
+          version="${latest#v}"
+          IFS='.' read -r major minor patch <<< "$version"
+
+          case "$bump" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+
+          echo "tag=v${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"
+
+      - name: Check tag does not exist
+        id: check
+        run: |
+          next="${{ steps.next.outputs.tag }}"
+          if git rev-parse "$next" >/dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          next="${{ steps.next.outputs.tag }}"
+          git tag "$next"
+          git push origin "$next"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-
 jobs:
   tag:
     name: Create version tag
@@ -18,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
 
       - name: Get latest tag
         id: latest
@@ -29,24 +27,29 @@ jobs:
         id: bump
         run: |
           latest="${{ steps.latest.outputs.tag }}"
-          # Get commits since last tag
           log=$(git log "${latest}..HEAD" --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
 
-          if echo "$log" | grep -qiE '^breaking|^BREAKING CHANGE|!:'; then
+          # Skip tagging when all commits are non-releasable (docs, ci, chore, style, test)
+          if ! echo "$log" | grep -qvE '^(docs|ci|chore|style|test)[:(]'; then
+            echo "type=skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if echo "$log" | grep -qE '!:|^BREAKING CHANGE'; then
             echo "type=major" >> "$GITHUB_OUTPUT"
-          elif echo "$log" | grep -qiE '^feat'; then
+          elif echo "$log" | grep -qE '^feat[:(]'; then
             echo "type=minor" >> "$GITHUB_OUTPUT"
           else
             echo "type=patch" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Compute next version
+        if: steps.bump.outputs.type != 'skip'
         id: next
         run: |
           latest="${{ steps.latest.outputs.tag }}"
           bump="${{ steps.bump.outputs.type }}"
 
-          # Strip leading v
           version="${latest#v}"
           IFS='.' read -r major minor patch <<< "$version"
 
@@ -59,6 +62,7 @@ jobs:
           echo "tag=v${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"
 
       - name: Check tag does not exist
+        if: steps.bump.outputs.type != 'skip'
         id: check
         run: |
           next="${{ steps.next.outputs.tag }}"
@@ -69,7 +73,7 @@ jobs:
           fi
 
       - name: Create and push tag
-        if: steps.check.outputs.skip == 'false'
+        if: steps.bump.outputs.type != 'skip' && steps.check.outputs.skip == 'false'
         run: |
           next="${{ steps.next.outputs.tag }}"
           git tag "$next"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,29 @@ go build -o dirtop .
 sudo mv dirtop /usr/local/bin/
 ```
 
+## Updating
+
+### Homebrew
+
+```bash
+brew update
+brew upgrade dirtop
+```
+
+### Using Go
+
+```bash
+go install github.com/arthurrio/dirtop@latest
+```
+
+### Manual / install.sh
+
+Re-run the install script or download the latest binary from the [releases page](https://github.com/arthurrio/dirtop/releases/latest):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/arthurrio/dirtop/main/install.sh | bash
+```
+
 ## Uninstall
 
 ### Homebrew


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically creates a version tag when commits land on `main`
- Bump type is inferred from conventional commit messages:
  - `feat:` -> minor bump (e.g. v0.2.0 -> v0.3.0)
  - `breaking`/`BREAKING CHANGE` -> major bump (e.g. v0.3.0 -> v1.0.0)
  - Everything else -> patch bump (e.g. v0.2.0 -> v0.2.1)
- The new tag triggers the existing `release.yml` workflow, which runs GoReleaser and updates the Homebrew formula

## How it works
1. Push/merge to `main` triggers `auto-tag.yml`
2. Workflow finds the latest semver tag
3. Reads commit messages since that tag to determine bump type
4. Creates and pushes the new tag
5. Tag push triggers `release.yml` -> GoReleaser -> Homebrew tap update

## Test plan
- [ ] Merge a commit with `fix:` prefix -> should create a patch tag
- [ ] Merge a commit with `feat:` prefix -> should create a minor tag
- [ ] Verify the release workflow triggers after auto-tag creates the new tag