### PR TITLE
Only record history entries on metric changes

### DIFF
--- a/chart.go
+++ b/chart.go
@@ -533,12 +533,9 @@ func formatAgo(d time.Duration) string {
 }
 
 // RenderHorizBar renders a horizontal histogram using block bars.
-// Each row represents one sample, with the most recent at the top.
-// interval is the real time between samples and is used to compute time labels.
-func RenderHorizBar(values []int, width, height int, interval time.Duration) string {
-	if interval <= 0 {
-		interval = time.Second
-	}
+// Each row represents a change snapshot, with the most recent at the top.
+// timestamps holds the real time each snapshot was taken; now is the reference.
+func RenderHorizBar(values []int, timestamps []time.Time, width, height int, now time.Time) string {
 	if height < 1 {
 		height = 1
 	}
@@ -548,22 +545,28 @@ func RenderHorizBar(values []int, width, height int, interval time.Duration) str
 	}
 
 	// Show the last `height` samples, most recent first.
-	samples := values
-	if len(samples) > height {
-		samples = samples[len(samples)-height:]
+	start := 0
+	if len(values) > height {
+		start = len(values) - height
 	}
+	samples := values[start:]
+	times := timestamps[start:]
 	n := len(samples)
 
-	// Compute labelWidth dynamically from the visible worst case.
-	maxOffset := time.Duration(n-1) * interval
+	// Compute labelWidth from the oldest visible timestamp.
+	var maxOffset time.Duration
+	if n > 0 {
+		maxOffset = now.Sub(times[0])
+	}
 	labelWidth := len(formatAgo(maxOffset))
 	if labelWidth < len("now") {
 		labelWidth = len("now")
 	}
 
+	const deltaWidth = 12 // Space for delta indicator like " +1.234".
 	const valueWidth = 10 // Right-aligned formatted number.
-	// Per-row layout: label + " " + bar + " " + value.
-	barArea := width - labelWidth - 2 - valueWidth
+	// Per-row layout: label + " " + bar + " " + value + delta.
+	barArea := width - labelWidth - 2 - valueWidth - deltaWidth
 	if barArea < 1 {
 		barArea = 1
 	}
@@ -571,31 +574,47 @@ func RenderHorizBar(values []int, width, height int, interval time.Duration) str
 	styleLabel := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorGray))
 	styleBar := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPurple))
 	styleValue := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorPurple))
+	stylePlus := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorGreen))
+	styleMinus := lipgloss.NewStyle().Foreground(lipgloss.Color(ColorOrange))
 
 	var sb strings.Builder
 	for i := 0; i < height; i++ {
 		if i > 0 {
 			sb.WriteString("\n")
 		}
-		sampleIdx := n - 1 - i // Index 0 is the most recent sample at the top.
+		sampleIdx := n - 1 - i // Most recent at the top.
 		if sampleIdx < 0 {
 			sb.WriteString(strings.Repeat(" ", width))
 			continue
 		}
 
 		val := samples[sampleIdx]
-		offset := time.Duration(n-1-sampleIdx) * interval
+		offset := now.Sub(times[sampleIdx])
 		label := fmt.Sprintf("%*s", labelWidth, formatAgo(offset))
 
 		barLen := val * barArea / maxVal
 		bar := strings.Repeat("█", barLen) + strings.Repeat(" ", barArea-barLen)
 		valueStr := fmt.Sprintf("%*s", valueWidth, formatNumber(val))
 
+		// Delta indicator relative to the previous snapshot.
+		deltaStr := strings.Repeat(" ", deltaWidth)
+		if sampleIdx > 0 {
+			diff := val - samples[sampleIdx-1]
+			if diff > 0 {
+				deltaStr = fmt.Sprintf("%*s", deltaWidth, "+"+formatNumber(diff))
+				deltaStr = stylePlus.Render(deltaStr)
+			} else if diff < 0 {
+				deltaStr = fmt.Sprintf("%*s", deltaWidth, formatNumber(diff))
+				deltaStr = styleMinus.Render(deltaStr)
+			}
+		}
+
 		sb.WriteString(styleLabel.Render(label))
 		sb.WriteString(" ")
 		sb.WriteString(styleBar.Render(bar))
 		sb.WriteString(" ")
 		sb.WriteString(styleValue.Render(valueStr))
+		sb.WriteString(deltaStr)
 	}
 	return sb.String()
 }

--- a/model.go
+++ b/model.go
@@ -17,6 +17,12 @@ type tickMsg time.Time
 
 const historyMaxLen = 3600
 
+// Snapshot records a Stats sample and the time it was observed.
+type Snapshot struct {
+	Stats
+	Time time.Time
+}
+
 // DefaultIntervals is the default list of refresh intervals.
 var DefaultIntervals = []time.Duration{
 	1 * time.Second,
@@ -41,7 +47,7 @@ var chartMetrics = [3]metricDef{
 
 // Model holds the Bubble Tea application state.
 type Model struct {
-	history     []Stats
+	history     []Snapshot
 	current     Stats
 	cwd         string
 	scanOpts    ScanOptions
@@ -75,6 +81,11 @@ func (m Model) metricValues() []int {
 		}
 	}
 	return vals
+}
+
+// statsChanged reports whether two Stats differ in the tracked metrics.
+func statsChanged(a, b Stats) bool {
+	return a.Files != b.Files || a.Dirs != b.Dirs || a.Lines != b.Lines
 }
 
 // formatInterval formats a duration as "1s", "30s", "1m", or "5m".
@@ -113,11 +124,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ScanMsg:
 		stats := Stats(msg)
-		if len(m.history) >= historyMaxLen {
-			m.history = m.history[1:]
-		}
-		m.history = append(m.history, stats)
 		m.current = stats
+		isNew := len(m.history) == 0 || statsChanged(m.history[len(m.history)-1].Stats, stats)
+		if isNew {
+			if len(m.history) >= historyMaxLen {
+				m.history = m.history[1:]
+			}
+			m.history = append(m.history, Snapshot{Stats: stats, Time: time.Now()})
+		}
 		return m, tickCmd(m.interval())
 
 	case tea.WindowSizeMsg:
@@ -244,7 +258,11 @@ func (m Model) View() string {
 	case ChartDelta:
 		chartStr = RenderDelta(metricVals, m.width, chartHeight)
 	case ChartHorizBar:
-		chartStr = RenderHorizBar(metricVals, m.width, chartHeight, m.interval())
+		times := make([]time.Time, len(m.history))
+		for i, s := range m.history {
+			times[i] = s.Time
+		}
+		chartStr = RenderHorizBar(metricVals, times, m.width, chartHeight, time.Now())
 	default:
 		chartStr = Render(metricVals, m.width, chartHeight)
 	}

--- a/model_test.go
+++ b/model_test.go
@@ -1,7 +1,10 @@
 // model_test.go
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestFormatNumber(t *testing.T) {
 	cases := []struct {
@@ -22,5 +25,81 @@ func TestFormatNumber(t *testing.T) {
 		if result != c.expected {
 			t.Errorf("formatNumber(%d) = %q, esperado %q", c.input, result, c.expected)
 		}
+	}
+}
+
+func TestStatsChanged(t *testing.T) {
+	base := Stats{Files: 10, Dirs: 3, Lines: 100}
+
+	cases := []struct {
+		name    string
+		a, b    Stats
+		changed bool
+	}{
+		{"identical", base, base, false},
+		{"files differ", base, Stats{Files: 11, Dirs: 3, Lines: 100}, true},
+		{"dirs differ", base, Stats{Files: 10, Dirs: 4, Lines: 100}, true},
+		{"lines differ", base, Stats{Files: 10, Dirs: 3, Lines: 101}, true},
+		{"scanning flag ignored", base, Stats{Files: 10, Dirs: 3, Lines: 100, Scanning: true}, false},
+	}
+
+	for _, c := range cases {
+		if got := statsChanged(c.a, c.b); got != c.changed {
+			t.Errorf("%s: statsChanged = %v, expected %v", c.name, got, c.changed)
+		}
+	}
+}
+
+func TestUpdate_AppendsHistoryOnlyOnChange(t *testing.T) {
+	m := Model{intervals: []time.Duration{time.Second}}
+
+	// First scan should always be recorded.
+	initial := Stats{Files: 5, Dirs: 2, Lines: 50, ByExt: map[string]int{}}
+	updated, _ := m.Update(ScanMsg(initial))
+	m = updated.(Model)
+	if len(m.history) != 1 {
+		t.Fatalf("expected 1 history entry after first scan, got %d", len(m.history))
+	}
+
+	// Same scan should not create a new history entry.
+	updated, _ = m.Update(ScanMsg(initial))
+	m = updated.(Model)
+	if len(m.history) != 1 {
+		t.Errorf("expected history to stay at 1 when stats unchanged, got %d", len(m.history))
+	}
+
+	// A changed scan should append a new entry.
+	changed := Stats{Files: 6, Dirs: 2, Lines: 50, ByExt: map[string]int{}}
+	updated, _ = m.Update(ScanMsg(changed))
+	m = updated.(Model)
+	if len(m.history) != 2 {
+		t.Errorf("expected 2 history entries after a change, got %d", len(m.history))
+	}
+
+	// Current stats must always reflect the latest scan, even without a new entry.
+	updated, _ = m.Update(ScanMsg(changed))
+	m = updated.(Model)
+	if m.current.Files != 6 {
+		t.Errorf("expected current.Files=6, got %d", m.current.Files)
+	}
+	if len(m.history) != 2 {
+		t.Errorf("expected history to stay at 2 when stats repeat, got %d", len(m.history))
+	}
+}
+
+func TestUpdate_RecordsTimestampOnChange(t *testing.T) {
+	m := Model{intervals: []time.Duration{time.Second}}
+	before := time.Now()
+
+	updated, _ := m.Update(ScanMsg(Stats{Files: 1, ByExt: map[string]int{}}))
+	m = updated.(Model)
+
+	after := time.Now()
+	if len(m.history) != 1 {
+		t.Fatalf("expected 1 history entry, got %d", len(m.history))
+	}
+	ts := m.history[0].Time
+	if ts.Before(before) || ts.After(after) {
+		t.Errorf("snapshot timestamp %v outside expected range [%v, %v]", ts, before, after)
 	}
 }


### PR DESCRIPTION
## Summary
- Scans continue running on the configured interval, but the history/chart only advances when `Files`, `Dirs`, or `Lines` actually change
- Each history entry stores the real timestamp of the change (new `Snapshot` struct)
- Horizontal bar chart labels now show real elapsed time (e.g. `-5s`, `-2m`, `-1h`) instead of fixed interval ticks
- Each row shows a signed delta against the previous snapshot: green `+N` for growth, orange `-N` for shrinkage
- `current` stats still reflect the latest scan, so the top metrics line remains live

## Behavior
Before: chart kept scrolling and shifting even when nothing changed, filling the view with static data.

After: the chart only moves when the codebase actually changes. Each bar represents a real event with a real timestamp, and the delta makes the magnitude of the change obvious at a glance.

## Test plan
- [x] `statsChanged` compares only Files/Dirs/Lines (not ByExt or Scanning)
- [x] First scan always records a history entry
- [x] Repeated identical scans do not add new entries
- [x] Changed scans append a new entry with a fresh timestamp
- [x] `current` always reflects the latest scan
- [ ] Visual check: let dirtop run on an idle dir — chart should not scroll
- [ ] Visual check: create/delete files — chart should show deltas with colors